### PR TITLE
chore: Setup CI to publish to npm repo when PR is merged into master

### DIFF
--- a/.github/workflows/publish.sh
+++ b/.github/workflows/publish.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# check this version is enable to release or not
+npx can-npm-publish
+if [ $? -eq 1 ] ; then
+  exit 255
+fi
+
+# get current version from package.json
+TAG=$(cat package.json | grep version | cut -d " " -f 4 | tr -d "," | tr -d '"')
+echo "add new tag to GitHub: ${TAG}"
+
+# Add tag to GitHub
+API_URL="https://api.github.com/repos/${REPO}/git/refs"
+
+curl -s -X POST $API_URL \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  -d @- << EOS
+{
+  "ref": "refs/tags/${TAG}",
+  "sha": "${COMMIT}"
+}
+EOS

--- a/.github/workflows/pull-request-develop.yml
+++ b/.github/workflows/pull-request-develop.yml
@@ -1,5 +1,7 @@
 name: Checking types and transpiling before PR merged.
-"on": pull_request
+on:
+  pull_request:
+    branches: develop
 
 jobs:
   build_and_preview:

--- a/.github/workflows/pull-request-master.yml
+++ b/.github/workflows/pull-request-master.yml
@@ -1,0 +1,38 @@
+name: publish to npm repository after PR merged.
+on:
+  pull_request:
+    branches: master
+    types: closed
+
+# @doc: https://dev.classmethod.jp/articles/github-actions-npm-automatic-release/
+jobs:
+  build_and_preview:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - uses: actions/checkout@v2
+
+    - name: Setup node env
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10.x
+          registry-url: 'https://registry.npmjs.org'
+        run:
+          ./publish.sh
+
+      - name: Install dependencies
+        run: npm install & npm install can-npm-publish
+
+      - name: Build contents
+        run: npm run build
+      
+      - name: add tags
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          REPO: ${{github.repository}}
+          COMMIT: ${{github.sha}}
+
+      - name: publish to npm repository
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Closes #8 

## What
- Setup CI to publish to npm repo when PR is merged into master
- improve CI to checking types when PR is created.

## Why
please read #8