### PR TITLE
fix: CI working only after PR merged into master

### DIFF
--- a/.github/workflows/pull-request-master.yml
+++ b/.github/workflows/pull-request-master.yml
@@ -1,11 +1,9 @@
 name: publish to npm repository after PR merged into master.
 on:
-  # pull_request:
-  push:
+  pull_request:
     branches: master
-    # types: closed
+    types: closed
 
-# @doc: https://dev.classmethod.jp/articles/github-actions-npm-automatic-release/
 jobs:
   build_and_preview:
     runs-on: ubuntu-latest


### PR DESCRIPTION
close #8 

## What
Only works when master is merged.

## Why
If this PR doesn't merged, every time master is updated, CI moves.